### PR TITLE
The Saint Louis Rams are now the LA Rams.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 [
   "SD" , "HOU", "WAS", "PHI", "NYG", "DAL", "SF" , "GB" ,
-  "STL", "ARI", "TEN", "PIT", "ATL", "NO" , "TB" , "NYJ",
+  "LA" , "ARI", "TEN", "PIT", "ATL", "NO" , "TB" , "NYJ",
   "KC" , "JAC", "OAK", "IND", "MIN", "DET", "CLE", "MIA",
   "CHI", "CIN", "DEN", "BAL", "BUF", "NE" , "SEA", "CAR"
 ].each do |team|


### PR DESCRIPTION
When running `python/create_initial_players.py` the import would fail because of trying to find team `LA` which did not exist. This changes `STL` in the database seed to `LA` to account for this team location change.