### PR TITLE
Update to Rails 4.1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 2.1.1
 script:
   - rubocop -R
+  - rake db:migrate RAILS_ENV="test"
   - rake test
   - rake assets:precompile RAILS_ENV="production"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.1.0'
+gem 'rails', '~> 4.1.16'
 
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'


### PR DESCRIPTION
Using `ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]` ...

When running the tests there would be many `Undefined method 'year' for nil:NilClass` errors. This error came from the code in `WithGameWeek.start_of_first_gameweek` specifically the line `Time.zone.parse(Settings.first_gameweek_start)`. Exploring the internet it seemed to be a bug with Rails. Updating to the latest 4.1.x version of Rails resolved the issue.